### PR TITLE
fix(edit): Only display double click text if editable

### DIFF
--- a/treeview.vue
+++ b/treeview.vue
@@ -14,7 +14,9 @@
       :draggable="draggable",
       :key="i"
     ).ll931217-vue-treeview
-    p Double click to create new node
+
+    if editable
+        p Double click to create new node
 </template>
 
 <script>


### PR DESCRIPTION
This text shouldn't be displayed unless the tree is editable